### PR TITLE
Dlp 44 be 단기 투두 리스트 생성 구현

### DIFF
--- a/be15-4th-b612-littleprince-be/src/main/java/littleprince/config/SecurityConfig.java
+++ b/be15-4th-b612-littleprince-be/src/main/java/littleprince/config/SecurityConfig.java
@@ -56,7 +56,8 @@ public class SecurityConfig {
                                 ).authenticated()
                                 /* 유저 권한 */
                                 .requestMatchers(HttpMethod.POST,
-                                        "/auth/logout"
+                                        "/auth/logout",
+                                        "/plans/short-todos"
                                 ).authenticated()
                                 .requestMatchers(HttpMethod.GET,
                                         "/plan/short/{date}/todo",

--- a/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/application/controller/Exam.java
+++ b/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/application/controller/Exam.java
@@ -1,4 +1,0 @@
-package littleprince.plan.command.application.controller;
-
-public class Exam {
-}

--- a/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/application/controller/ShortTodoCommandController.java
+++ b/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/application/controller/ShortTodoCommandController.java
@@ -1,0 +1,31 @@
+package littleprince.plan.command.application.controller;
+
+import jakarta.validation.Valid;
+import littleprince.common.dto.ApiResponse;
+import littleprince.config.security.model.CustomUserDetail;
+import littleprince.plan.command.application.dto.request.CreateShortTodoRequestDto;
+import littleprince.plan.command.service.ShortTodoCommandService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/plans/short-todos")
+public class ShortTodoCommandController {
+    private final ShortTodoCommandService shortTodoCommandService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<Void>> createShortTodo(
+            @AuthenticationPrincipal CustomUserDetail userDetail,
+            @RequestBody @Valid CreateShortTodoRequestDto dto
+            ){
+        shortTodoCommandService.create(userDetail.getMemberId(), dto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(null));
+    }
+}

--- a/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/application/dto/request/CreateShortTodoRequestDto.java
+++ b/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/application/dto/request/CreateShortTodoRequestDto.java
@@ -1,0 +1,18 @@
+package littleprince.plan.command.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+public class CreateShortTodoRequestDto {
+    @NotBlank
+    private String content;
+
+    @NotNull
+    private LocalDate date;
+}

--- a/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/application/dto/request/Exam.java
+++ b/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/application/dto/request/Exam.java
@@ -1,4 +1,0 @@
-package littleprince.plan.command.application.dto.request;
-
-public class Exam {
-}

--- a/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/domain/aggregate/Exam.java
+++ b/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/domain/aggregate/Exam.java
@@ -1,4 +1,0 @@
-package littleprince.plan.command.domain.aggregate;
-
-public class Exam {
-}

--- a/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/domain/aggregate/Task.java
+++ b/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/domain/aggregate/Task.java
@@ -1,0 +1,45 @@
+package littleprince.plan.command.domain.aggregate;
+
+import jakarta.persistence.*;
+import littleprince.common.domain.StatusType;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "task")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Task {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long taskId;
+
+    private Long memberId;
+
+    private Long projectId; // 단기는 null
+
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    private StatusType isChecked;
+
+    private LocalDate date;
+
+    private LocalDateTime createdAt;
+
+    @Builder
+    public Task(Long memberId, Long projectId, String content, LocalDate date) {
+        this.memberId = memberId;
+        this.projectId = projectId;
+        this.content = content;
+        this.date = date;
+        this.isChecked = StatusType.N;
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/mapper/ShortListCommandMapper.java
+++ b/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/mapper/ShortListCommandMapper.java
@@ -1,9 +1,0 @@
-package littleprince.plan.command.mapper;
-
-import littleprince.member.command.domain.aggregate.MemberDTO;
-import org.apache.ibatis.annotations.Mapper;
-
-@Mapper
-public interface ShortListCommandMapper {
-    void insertMember(MemberDTO member);
-}

--- a/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/mapper/ShortTodoCommandMapper.java
+++ b/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/mapper/ShortTodoCommandMapper.java
@@ -1,0 +1,17 @@
+package littleprince.plan.command.mapper;
+
+import littleprince.plan.command.application.dto.request.CreateShortTodoRequestDto;
+import littleprince.plan.command.domain.aggregate.Task;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ShortTodoCommandMapper {
+    public Task toEntity(CreateShortTodoRequestDto dto, Long memberId) {
+        return Task.builder()
+                .memberId(memberId)
+                .projectId(null)    // 단기 투두
+                .content(dto.getContent())
+                .date(dto.getDate())
+                .build();
+    }
+}

--- a/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/repository/TaskRepository.java
+++ b/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/repository/TaskRepository.java
@@ -1,0 +1,7 @@
+package littleprince.plan.command.repository;
+
+import littleprince.plan.command.domain.aggregate.Task;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TaskRepository extends JpaRepository<Task, Long> {
+}

--- a/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/service/ShortTodoCommandService.java
+++ b/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/service/ShortTodoCommandService.java
@@ -1,0 +1,22 @@
+package littleprince.plan.command.service;
+
+import littleprince.plan.command.application.dto.request.CreateShortTodoRequestDto;
+import littleprince.plan.command.domain.aggregate.Task;
+import littleprince.plan.command.mapper.ShortTodoCommandMapper;
+import littleprince.plan.command.repository.TaskRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class ShortTodoCommandService {
+    private final TaskRepository taskRepository;
+    private final ShortTodoCommandMapper mapper;
+
+    @Transactional
+    public void create(Long memberId, CreateShortTodoRequestDto dto) {
+        Task task = mapper.toEntity(dto, memberId);
+        taskRepository.save(task);
+    }
+}


### PR DESCRIPTION
### 🛠️ PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] ✨ 기능 추가
- [ ] 🗑️ 기능 삭제
- [ ] 🔮 기능 수정
- [ ] 🐛 버그 수정
- [ ] 🧱 의존성, 환경 변수, 빌드 관련 코드 업데이트


### 📝 작업 내용

- 단기 투두 리스트 생성 구현 (JPA)
- SecurityConfig 파일에 엔드포인트 명시적으로 허용하도록 구현


### ✅ 테스트 결과
- postman 응답 반환 성공
![image](https://github.com/user-attachments/assets/30add082-1859-482e-9247-f2e2fe762e46)