### PR TITLE
Dlp 70 be 단기 투두 체크 상태 토글 기능 구현

### DIFF
--- a/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/application/controller/ShortTodoCommandController.java
+++ b/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/application/controller/ShortTodoCommandController.java
@@ -1,5 +1,6 @@
 package littleprince.plan.command.application.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import littleprince.common.dto.ApiResponse;
 import littleprince.config.security.model.CustomUserDetail;
@@ -32,6 +33,16 @@ public class ShortTodoCommandController {
             @PathVariable Long taskId
     ) {
         shortTodoCommandService.deleteShortTodo(userDetail.getMemberId(), taskId);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @PatchMapping("/{taskId}/check")
+    @Operation(summary = "체크 상태 토글", description = "해당 단기 투두의 체크 상태를 토글합니다.")
+    public ResponseEntity<ApiResponse<Void>> toggleCheck(
+            @AuthenticationPrincipal CustomUserDetail userDetail,
+            @PathVariable Long taskId
+    ) {
+        shortTodoCommandService.toggleCheck(userDetail.getMemberId(), taskId);
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 }

--- a/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/application/service/ShortTodoCommandService.java
+++ b/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/application/service/ShortTodoCommandService.java
@@ -28,4 +28,11 @@ public class ShortTodoCommandService {
                 .orElseThrow(() -> new BusinessException(PlanErrorCode.ACCESS_DENIED));
         taskRepository.delete(task);
     }
+
+    @Transactional
+    public void toggleCheck(Long memberId, Long taskId) {
+        Task task = taskRepository.findByTaskIdAndMemberId(taskId, memberId)
+                .orElseThrow(() -> new BusinessException(PlanErrorCode.ACCESS_DENIED));
+        task.toggleCheck();
+    }
 }

--- a/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/domain/aggregate/Task.java
+++ b/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/domain/aggregate/Task.java
@@ -42,4 +42,8 @@ public class Task {
         this.isChecked = StatusType.N;
         this.createdAt = LocalDateTime.now();
     }
+
+    public void toggleCheck() {
+        this.isChecked = this.isChecked == StatusType.Y ? StatusType.N : StatusType.Y;
+    }
 }


### PR DESCRIPTION
### 🛠️ PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] ✨ 기능 추가
- [ ] 🗑️ 기능 삭제
- [ ] 🔮 기능 수정
- [ ] 🐛 버그 수정
- [ ] 🧱 의존성, 환경 변수, 빌드 관련 코드 업데이트


### 📝 작업 내용

- 단기 투두 체크 상태 API 구현
- Postman에서 send 누르면 체크 표시 상태 바뀜 -> 조회 API에서 테스트 완료



### ✅ 테스트 결과
![image](https://github.com/user-attachments/assets/d549beb4-7dd9-4db4-badb-4cb63b10a075)

![image](https://github.com/user-attachments/assets/651c6d56-2ee4-44dc-90fc-0a9fd40d061d)
