### PR TITLE
Dlp 48 be 장기 프로젝트 생성 및 하위 투두 리스트 생성 구현

### DIFF
--- a/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/application/controller/LongTodoCommandController.java
+++ b/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/application/controller/LongTodoCommandController.java
@@ -1,0 +1,33 @@
+package littleprince.plan.command.application.controller;
+
+import jakarta.validation.Valid;
+import littleprince.common.dto.ApiResponse;
+import littleprince.config.security.model.CustomUserDetail;
+import littleprince.plan.command.application.dto.request.CreateLongTodoRequestDto;
+import littleprince.plan.command.application.service.LongTodoCommandService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/plans/long-todos")
+@Tag(name = "장기 투두 API", description = "장기 프로젝트 기반 투두 생성 API")
+public class LongTodoCommandController {
+
+    private final LongTodoCommandService longTodoCommandService;
+
+    @PostMapping
+    @Operation(summary = "장기 투두 생성", description = "하나의 프로젝트와 연결된 여러 개의 체크리스트 항목을 생성합니다.")
+    public ResponseEntity<ApiResponse<Void>> createProjectWithTasks(
+            @AuthenticationPrincipal CustomUserDetail user,
+            @RequestBody @Valid CreateLongTodoRequestDto dto
+    ) {
+        longTodoCommandService.createProjectWithTasks(user.getMemberId(), dto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(null));
+    }
+}

--- a/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/application/controller/ProjectTaskCommandController.java
+++ b/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/application/controller/ProjectTaskCommandController.java
@@ -1,0 +1,29 @@
+package littleprince.plan.command.application.controller;
+
+import jakarta.validation.Valid;
+import littleprince.common.dto.ApiResponse;
+import littleprince.config.security.model.CustomUserDetail;
+import littleprince.plan.command.application.dto.request.CreateProjectTaskRequestDto;
+import littleprince.plan.command.application.service.ProjectTaskCommandService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/plans/projects/{projectId}/tasks")
+public class ProjectTaskCommandController {
+
+    private final ProjectTaskCommandService projectTaskCommandService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<Void>> createProjectTasks(
+            @AuthenticationPrincipal CustomUserDetail userDetail,
+            @PathVariable Long projectId,
+            @RequestBody @Valid CreateProjectTaskRequestDto dto
+            ){
+        projectTaskCommandService.createProjectTasks(userDetail.getMemberId(),projectId, dto);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+}

--- a/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/application/controller/ProjectTaskCommandController.java
+++ b/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/application/controller/ProjectTaskCommandController.java
@@ -1,5 +1,6 @@
 package littleprince.plan.command.application.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import littleprince.common.dto.ApiResponse;
 import littleprince.config.security.model.CustomUserDetail;
@@ -18,6 +19,7 @@ public class ProjectTaskCommandController {
     private final ProjectTaskCommandService projectTaskCommandService;
 
     @PostMapping
+    @Operation(summary = "장기 프로젝트 하위 체크리스트 생성", description = "특정 프로젝트에 여러 개의 할 일을 추가합니다.")
     public ResponseEntity<ApiResponse<Void>> createProjectTasks(
             @AuthenticationPrincipal CustomUserDetail userDetail,
             @PathVariable Long projectId,

--- a/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/application/dto/request/CreateLongTodoRequestDto.java
+++ b/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/application/dto/request/CreateLongTodoRequestDto.java
@@ -1,0 +1,25 @@
+package littleprince.plan.command.application.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Schema(description = "장기 투두 리스트 생성 요청 DTO")
+public class CreateLongTodoRequestDto {
+
+    @Schema(description = "프로젝트 제목", example = "프론트엔드 세팅 완료하기")
+    @NotBlank
+    private String title;
+
+    @Schema(description = "시작 날짜", example = "2025-05-14")
+    @NotNull
+    private LocalDate startDate;
+
+    @Schema(description = "종료 날짜", example = "2025-08-20")
+    @NotNull
+    private LocalDate endDate;
+}

--- a/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/application/dto/request/CreateLongTodoRequestDto.java
+++ b/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/application/dto/request/CreateLongTodoRequestDto.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 import java.time.LocalDate;
 
 @Getter
-@Schema(description = "장기 투두 리스트 생성 요청 DTO")
+@Schema(description = "장기 투두 프로젝트 생성 요청 DTO")
 public class CreateLongTodoRequestDto {
 
     @Schema(description = "프로젝트 제목", example = "프론트엔드 세팅 완료하기")

--- a/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/application/dto/request/CreateProjectTaskRequestDto.java
+++ b/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/application/dto/request/CreateProjectTaskRequestDto.java
@@ -1,0 +1,28 @@
+package littleprince.plan.command.application.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "장기 프로젝트 하위 체크리스트 생성 요청 DTO")
+public class CreateProjectTaskRequestDto {
+    @NotNull
+    private List<ProjectTaskDto> tasks;
+
+    @Getter
+    @NoArgsConstructor
+    public static class ProjectTaskDto {
+        @NotBlank
+        private String content;
+
+        @NotNull
+        private LocalDate date;
+    }
+}

--- a/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/application/dto/request/CreateProjectTaskRequestDto.java
+++ b/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/application/dto/request/CreateProjectTaskRequestDto.java
@@ -13,16 +13,21 @@ import java.util.List;
 @NoArgsConstructor
 @Schema(description = "장기 프로젝트 하위 체크리스트 생성 요청 DTO")
 public class CreateProjectTaskRequestDto {
+
     @NotNull
+    @Schema(description = "체크리스트 항목 목록", example = "[{\"content\": \"요구사항 정리\", \"date\": \"2025-05-21\"}]")
     private List<ProjectTaskDto> tasks;
 
     @Getter
     @NoArgsConstructor
+    @Schema(description = "개별 체크리스트 항목 DTO")
     public static class ProjectTaskDto {
         @NotBlank
+        @Schema(description = "할 일 내용", example = "요구사항 명세서 작성")
         private String content;
 
         @NotNull
+        @Schema(description = "일정 날짜", example = "2025-05-21")
         private LocalDate date;
     }
 }

--- a/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/application/service/LongTodoCommandService.java
+++ b/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/application/service/LongTodoCommandService.java
@@ -1,0 +1,31 @@
+package littleprince.plan.command.application.service;
+
+import jakarta.transaction.Transactional;
+import littleprince.plan.command.application.dto.request.CreateLongTodoRequestDto;
+import littleprince.plan.command.domain.aggregate.Project;
+import littleprince.plan.command.repository.ProjectRepository;
+import littleprince.plan.command.repository.TaskRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LongTodoCommandService {
+
+    private final ProjectRepository projectRepository;
+    private final TaskRepository taskRepository;
+
+    @Transactional
+    public void createProjectWithTasks(Long memberId, CreateLongTodoRequestDto dto) {
+        // 프로젝트 생성 및 저장
+        Project project = Project.builder()
+                .memberId(memberId)
+                .title(dto.getTitle())
+                .startDate(dto.getStartDate())
+                .endDate(dto.getEndDate())
+                .build();
+
+        projectRepository.save(project);
+
+    }
+}

--- a/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/application/service/ProjectTaskCommandService.java
+++ b/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/application/service/ProjectTaskCommandService.java
@@ -1,0 +1,40 @@
+package littleprince.plan.command.application.service;
+
+import littleprince.plan.command.application.dto.request.CreateProjectTaskRequestDto;
+import littleprince.plan.command.domain.aggregate.Task;
+import littleprince.plan.command.repository.ProjectRepository;
+import littleprince.plan.command.repository.TaskRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ProjectTaskCommandService {
+
+    private final ProjectRepository projectRepository;
+    private final TaskRepository taskRepository;
+
+    @Transactional
+    public void createProjectTasks(Long memberId, Long projectId, CreateProjectTaskRequestDto dto) {
+        // 1. project 존재 여부 확인
+        if (!projectRepository.existsById(projectId)) {
+            throw new IllegalArgumentException("해당 projectId는 존재하지 않습니다.");
+        }
+
+        // 2. task 리스트 생성
+        List<Task> tasks = dto.getTasks().stream()
+                .map(taskDto -> Task.builder()
+                        .memberId(memberId)
+                        .projectId(projectId)
+                        .content(taskDto.getContent())
+                        .date(taskDto.getDate())
+                        .build()
+                ).toList();
+
+        // 3. 저장
+        taskRepository.saveAll(tasks);
+    }
+}

--- a/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/domain/aggregate/Project.java
+++ b/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/domain/aggregate/Project.java
@@ -1,0 +1,35 @@
+package littleprince.plan.command.domain.aggregate;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "project")
+public class Project {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long projectId;
+
+    private Long memberId;
+
+    private String title;
+
+    private LocalDate startDate;
+
+    private LocalDate endDate;
+
+    @Builder
+    public Project(Long memberId, String title, LocalDate startDate, LocalDate endDate) {
+        this.memberId = memberId;
+        this.title = title;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+}

--- a/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/domain/aggregate/Task.java
+++ b/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/domain/aggregate/Task.java
@@ -2,14 +2,13 @@ package littleprince.plan.command.domain.aggregate;
 
 import jakarta.persistence.*;
 import littleprince.common.domain.StatusType;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+@AllArgsConstructor
+@Builder
 @Entity
 @Table(name = "task")
 @Getter
@@ -27,23 +26,23 @@ public class Task {
     private String content;
 
     @Enumerated(EnumType.STRING)
-    private StatusType isChecked;
+    private StatusType checked;
 
     private LocalDate date;
 
     private LocalDateTime createdAt;
 
     @Builder
-    public Task(Long memberId, Long projectId, String content, LocalDate date) {
+    public Task(Long memberId, Long projectId, String content, LocalDate date, StatusType checked) {
         this.memberId = memberId;
         this.projectId = projectId;
         this.content = content;
         this.date = date;
-        this.isChecked = StatusType.N;
+        this.checked = checked;
         this.createdAt = LocalDateTime.now();
     }
 
     public void toggleCheck() {
-        this.isChecked = this.isChecked == StatusType.Y ? StatusType.N : StatusType.Y;
+        this.checked = this.checked == StatusType.Y ? StatusType.N : StatusType.Y;
     }
 }

--- a/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/domain/aggregate/Task.java
+++ b/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/domain/aggregate/Task.java
@@ -26,7 +26,9 @@ public class Task {
     private String content;
 
     @Enumerated(EnumType.STRING)
-    private StatusType checked;
+    @Column(name = "is_checked")
+    @Builder.Default
+    private StatusType checked = StatusType.N;
 
     private LocalDate date;
 

--- a/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/repository/ProjectRepository.java
+++ b/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/repository/ProjectRepository.java
@@ -1,0 +1,7 @@
+package littleprince.plan.command.repository;
+
+import littleprince.plan.command.domain.aggregate.Project;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectRepository extends JpaRepository<Project, Long> {
+}


### PR DESCRIPTION
### 🛠️ PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] ✨ 기능 추가
- [ ] 🗑️ 기능 삭제
- [ ] 🔮 기능 수정
- [ ] 🐛 버그 수정
- [ ] 🧱 의존성, 환경 변수, 빌드 관련 코드 업데이트


### 📝 작업 내용
- 장기 프로젝트 생성 구현
- 장기 프로젝트의 하위 투두 리스트 생성 구현
- swagger 처리 완료


### 🔗 관련 이슈

closes #74


### ✅ 테스트 결과
- 장기 프로젝트 생성
![image](https://github.com/user-attachments/assets/6095d8b1-ce16-4cb4-875e-590fc54e146f)

- 장기 프로젝트 하위 투두 리스트 생성
![image](https://github.com/user-attachments/assets/51ad9f58-48e9-43f1-86ad-73b058e4f599)

