### PR TITLE
Dlp 49 be 장기 투두 리스트 삭제 구현

### DIFF
--- a/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/application/controller/ProjectTaskCommandController.java
+++ b/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/application/controller/ProjectTaskCommandController.java
@@ -38,4 +38,14 @@ public class ProjectTaskCommandController {
         projectTaskCommandService.toggleProjectTaskCheck(userDetail.getMemberId(), taskId);
         return ResponseEntity.ok(ApiResponse.success(null));
     }
+
+    @DeleteMapping("/{taskId}")
+    @Operation(summary = "장기 투두 체크리스트 항목 삭제", description = "장기 프로젝트에 속한 체크리스트 항목(task)를 삭제합니다.")
+    public ResponseEntity<ApiResponse<Void>> deleteProjectTask(
+            @AuthenticationPrincipal CustomUserDetail userDetail,
+            @PathVariable Long taskId
+    ) {
+        projectTaskCommandService.deleteProjectTask(userDetail.getMemberId(), taskId);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
 }

--- a/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/application/service/ProjectTaskCommandService.java
+++ b/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/application/service/ProjectTaskCommandService.java
@@ -57,4 +57,11 @@ public class ProjectTaskCommandService {
 
         task.toggleCheck();
     }
+
+    @Transactional
+    public void deleteProjectTask(Long memberId, Long taskId) {
+        Task task = taskRepository.findByTaskIdAndMemberId(taskId, memberId)
+                .orElseThrow(() -> new BusinessException(PlanErrorCode.ACCESS_DENIED));
+        taskRepository.delete(task);
+    }
 }


### PR DESCRIPTION
### 🛠️ PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] ✨ 기능 추가
- [ ] 🗑️ 기능 삭제
- [ ] 🔮 기능 수정
- [ ] 🐛 버그 수정
- [ ] 🧱 의존성, 환경 변수, 빌드 관련 코드 업데이트


### 📝 작업 내용
- 장기 프로젝트의 하위 투두 체크 리스트 항목을 삭제하도록 구현

### 🔗 관련 이슈

closes #75 


### ✅ 테스트 결과
![image](https://github.com/user-attachments/assets/e6ea9b5e-9c09-49f1-8fec-53bbe1d7d661)
