### PR TITLE
Dlp 51 be 장기 플랜 목록 삭제

### DIFF
--- a/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/application/controller/ProjectCommandController.java
+++ b/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/application/controller/ProjectCommandController.java
@@ -1,0 +1,28 @@
+package littleprince.plan.command.application.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import littleprince.common.dto.ApiResponse;
+import littleprince.config.security.model.CustomUserDetail;
+import littleprince.plan.command.application.service.ProjectCommandService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/plans/projects")
+public class ProjectCommandController {
+
+    private final ProjectCommandService projectCommandService;
+
+    @DeleteMapping("/{projectId}")
+    @Operation(summary = "장기 프로젝트 삭제", description = "장기 프로젝트를 삭제합니다. 이때 해당 프로젝트에 속한 투두(Task)들도 함께 삭제됩니다.")
+    public ResponseEntity<ApiResponse<Void>> deleteProject(
+            @AuthenticationPrincipal CustomUserDetail userDetail,
+            @PathVariable Long projectId
+    ) {
+        projectCommandService.deleteProject(userDetail.getMemberId(), projectId);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+}

--- a/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/application/service/ProjectCommandService.java
+++ b/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/command/application/service/ProjectCommandService.java
@@ -1,0 +1,28 @@
+package littleprince.plan.command.application.service;
+
+import littleprince.common.exception.BusinessException;
+import littleprince.plan.command.domain.aggregate.Project;
+import littleprince.plan.command.repository.ProjectRepository;
+import littleprince.plan.exception.PlanErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ProjectCommandService {
+
+    private final ProjectRepository projectRepository;
+
+    @Transactional
+    public void deleteProject(Long memberId, Long projectId) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new BusinessException(PlanErrorCode.PROJECT_NOT_FOUND));
+
+        if(!project.getMemberId().equals(memberId)) {
+            throw new BusinessException(PlanErrorCode.ACCESS_DENIED);
+        }
+
+        projectRepository.delete(project);  // task는 ON DELETE CASCADE로 자동 삭제됨
+    }
+}

--- a/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/exception/PlanErrorCode.java
+++ b/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/exception/PlanErrorCode.java
@@ -13,7 +13,8 @@ public enum PlanErrorCode implements ErrorCode {
     /* 각 도메인마다 ERROR CODE 작성 */
     ACCESS_DENIED("20001", "해당 투두 항목에 대한 삭제 권한이 없습니다.", HttpStatus.FORBIDDEN),
     NOT_FOUND_TASK("20002", "해당 투두 항목을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    INVALID_PROJECT_TASK("20003", "장기 투두 항목이 아닙니다.", HttpStatus.BAD_REQUEST);
+    INVALID_PROJECT_TASK("20003", "장기 투두 항목이 아닙니다.", HttpStatus.BAD_REQUEST),
+    PROJECT_NOT_FOUND("20004", "해당 프로젝트가 존재하지 않습니다.", HttpStatus.NOT_FOUND);
 
 
     private final String code;


### PR DESCRIPTION
### 🛠️ PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] ✨ 기능 추가
- [ ] 🗑️ 기능 삭제
- [ ] 🔮 기능 수정
- [ ] 🐛 버그 수정
- [ ] 🧱 의존성, 환경 변수, 빌드 관련 코드 업데이트


### 📝 작업 내용

- 장기 프로젝트를 삭제하는 로직 구현
- 장기 프로젝트를 삭제하면 해당 프로젝트의 하위 투두 리스트들도 일괄 삭제(CASCADE)



### ✅ 테스트 결과

![image](https://github.com/user-attachments/assets/ed66402a-5d2a-451e-95cc-68172c4adaec)
