### PR TITLE
Dlp 109 be 단기 플랜 전체 조회 api 구현

### DIFF
--- a/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/query/controller/ShortListQueryController.java
+++ b/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/query/controller/ShortListQueryController.java
@@ -3,6 +3,7 @@ package littleprince.plan.query.controller;
 import littleprince.common.dto.ApiResponse;
 import littleprince.config.security.model.CustomUserDetail;
 import littleprince.plan.query.dto.response.ShortListResponse;
+import littleprince.plan.query.dto.response.ShortListsAllResponse;
 import littleprince.plan.query.dto.response.ShortPlanDateResponse;
 import littleprince.plan.query.service.ShortListQueryService;
 import lombok.RequiredArgsConstructor;
@@ -23,7 +24,7 @@ public class ShortListQueryController {
 
     private final ShortListQueryService planQueryService;
 
-    /* 단기리스트 조회 */
+    /* 단기 리스트 조회 */
     @GetMapping("/short/{date}/todo")
     public ResponseEntity<ApiResponse<ShortListResponse>> getShortList(
             @AuthenticationPrincipal CustomUserDetail customUserDetail,
@@ -37,7 +38,7 @@ public class ShortListQueryController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    /* 단기플랜 날짜 여부 조회 */
+    /* 단기 플랜 날짜 여부 조회 */
     @GetMapping("/short")
     public ResponseEntity<ApiResponse<ShortPlanDateResponse>> getShortDates(
             @AuthenticationPrincipal CustomUserDetail customUserDetail
@@ -46,6 +47,19 @@ public class ShortListQueryController {
         Long memberId = customUserDetail.getMemberId();
 
         ShortPlanDateResponse response = planQueryService.getShortDates(memberId);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    // 단기 플랜 전체 조회 => task table 안에 있는 오늘 날짜 전체 조회(장기 플랜 내에 있는 것까지 포함한 모든 단기 리스트 조회)
+    @GetMapping("/short/{date}/all")
+    public ResponseEntity<ApiResponse<ShortListsAllResponse>> getShortListsAll(
+            @AuthenticationPrincipal CustomUserDetail customUserDetail,
+            @PathVariable Date date
+    ){
+        Long memberId = customUserDetail.getMemberId();
+
+        ShortListsAllResponse response = planQueryService.getShortListsAll(memberId, date);
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/query/dto/response/ShortListsAllDTO.java
+++ b/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/query/dto/response/ShortListsAllDTO.java
@@ -1,0 +1,20 @@
+package littleprince.plan.query.dto.response;
+
+import littleprince.common.domain.StatusType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.sql.Date;
+
+@Getter
+@Builder
+public class ShortListsAllDTO {
+
+    private Long taskId;
+    private Long projectId;
+    private Long memberId;
+    private String content;
+    private StatusType isChecked;
+    private Date date;
+
+}

--- a/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/query/dto/response/ShortListsAllResponse.java
+++ b/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/query/dto/response/ShortListsAllResponse.java
@@ -1,0 +1,14 @@
+package littleprince.plan.query.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Builder
+@Getter
+public class ShortListsAllResponse {
+
+    private final List<ShortListsAllDTO> shortListsAll;
+
+}

--- a/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/query/mapper/ShortListQueryMapper.java
+++ b/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/query/mapper/ShortListQueryMapper.java
@@ -2,6 +2,7 @@ package littleprince.plan.query.mapper;
 
 import littleprince.plan.query.dto.response.AiShortPlanDTO;
 import littleprince.plan.query.dto.response.ShortListDTO;
+import littleprince.plan.query.dto.response.ShortListsAllDTO;
 import littleprince.plan.query.dto.response.ShortPlanDateDTO;
 import org.apache.ibatis.annotations.Mapper;
 
@@ -14,6 +15,8 @@ public interface ShortListQueryMapper {
     /* 단기 리스트 목록 조회 */
     List<ShortListDTO> getShortList(Long memberId, Date date);
 
+    /* 단기 리스트 전체 조회 */
+    List<ShortListsAllDTO> getShortListsAll(Long memberId, Date date);
 
     /* 단기 플랜 여부 조회 */
     List<ShortPlanDateDTO> getShortDates(Long memberId);

--- a/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/query/service/ShortListQueryService.java
+++ b/be15-4th-b612-littleprince-be/src/main/java/littleprince/plan/query/service/ShortListQueryService.java
@@ -1,10 +1,6 @@
 package littleprince.plan.query.service;
 
-import littleprince.plan.query.dto.response.AiShortPlanDTO;
-import littleprince.plan.query.dto.response.ShortListDTO;
-import littleprince.plan.query.dto.response.ShortListResponse;
-import littleprince.plan.query.dto.response.ShortPlanDateDTO;
-import littleprince.plan.query.dto.response.ShortPlanDateResponse;
+import littleprince.plan.query.dto.response.*;
 import littleprince.plan.query.mapper.ShortListQueryMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -28,7 +24,16 @@ public class ShortListQueryService {
                 .build();
     }
 
-    /* 단기플랜 여부 조회 */
+    // 모든 단기 리스트 조회
+    public ShortListsAllResponse getShortListsAll(Long memberId, Date date) {
+        List<ShortListsAllDTO> listAllDTO = shortListQueryMapper.getShortListsAll(memberId, date);
+
+        return ShortListsAllResponse.builder()
+                .shortListsAll(listAllDTO)
+                .build();
+    }
+
+    /* 단기 플랜 여부 조회 */
     public ShortPlanDateResponse getShortDates(Long memberId) {
         List<ShortPlanDateDTO> planDateDTO = shortListQueryMapper.getShortDates(memberId);
 
@@ -36,8 +41,9 @@ public class ShortListQueryService {
                 .planDateDTO(planDateDTO)
                 .build();
     }
+
     /* Ai에서 사용할 사용자의 단기 리스트 전체 조회 */
-    public List<AiShortPlanDTO> getMemberShortPlan(Long memberId){
+    public List<AiShortPlanDTO> getMemberShortPlan(Long memberId) {
         return shortListQueryMapper.getShortPlanByMemberId(memberId);
     }
 
@@ -58,6 +64,5 @@ public class ShortListQueryService {
     public long countUncheckedTasks(Long memberId, Date date) {
         return shortListQueryMapper.countUncheckedTasks(memberId, date);
     }
-
 
 }

--- a/be15-4th-b612-littleprince-be/src/main/resources/mappers/plan/ShortListQueryMapper.xml
+++ b/be15-4th-b612-littleprince-be/src/main/resources/mappers/plan/ShortListQueryMapper.xml
@@ -50,4 +50,18 @@
         AND is_checked = 'N'
     </select>
 
+    <select id="getShortListsAll" resultType="littleprince.plan.query.dto.response.ShortListsAllDTO">
+        SELECT
+        task_id
+        , project_id
+        , member_id
+        , content
+        , is_checked
+        , date
+        FROM task
+        WHERE member_id = #{ memberId }
+        AND date = #{ date }
+        ORDER BY created_at
+    </select>
+
 </mapper>


### PR DESCRIPTION
### 🛠️ PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] ✨ 기능 추가
- [ ] 🗑️ 기능 삭제
- [ ] 🔮 기능 수정
- [ ] 🐛 버그 수정
- [ ] 🧱 의존성, 환경 변수, 빌드 관련 코드 업데이트


### 📝 작업 내용

단기 플랜 전체 조회 api 구현

### 🔗 관련 이슈

<!-- ex: closes #12 -->
closes #201 

### ✅ 테스트 결과
포스트맨 확인
